### PR TITLE
Fix elastic field limit increase in some cases

### DIFF
--- a/app/database/elkdb.py
+++ b/app/database/elkdb.py
@@ -417,8 +417,11 @@ class ES_DB:
 
             try:
                 
+                if 'caused_by' in doc['index']['error']:
+                    doc_reason = doc['index']['error']['caused_by']['reason']
+                else:
+                    doc_reason = doc['index']['error']['reason']
 
-                doc_reason = doc['index']['error']['reason']
                 logger.logger(level=logger.WARNING , type="elasticsearch", message=record_msg_info + ": record failed" , reason=doc_reason)
                 
                 # === if the error is the limitation on the fields number, get the add 1000 to the limitation and try again


### PR DESCRIPTION
Sometimes indexing error responses contain a nested `caused_by` object. In such a case, Kuiper only sees a generic "parsing failure" error when the field limit of 1000 has been reached, meaning it won't attempt to increase the limit.

This patch rectifies that problem by first checking if `caused_by` is present. Similar logic can already be found in the `query` function of the same file.