### PR TITLE
Add missing User Agent path to iis_logs configuration

### DIFF
--- a/kuiper/app/parsers/iis_logs/configuration.json
+++ b/kuiper/app/parsers/iis_logs/configuration.json
@@ -23,6 +23,7 @@
           "name": "Query"
         },
         {
+          "path": "cs_user_agent",
           "name": "User Agent"
         },
         {
@@ -41,4 +42,3 @@
       "description": "Processes IIS access logs."
     }
 ]
-  


### PR DESCRIPTION
The `path` string was missing for the User Agent field in the previous merge request. My apologies.