### PR TITLE
Bug Fix: Flask and Celery Docker Images

### DIFF
--- a/kuiper/requirements_2.7.txt
+++ b/kuiper/requirements_2.7.txt
@@ -29,7 +29,7 @@ python-registry==1.0.4
 python-evtx==0.6.1
 redis==3.3.11
 gunicorn==19.4.5
-gevent==1.4.0
+gevent==1.2.2
 psutil==5.7.0
 libesedb-python==20210424
 python-ldap==3.3.1


### PR DESCRIPTION
**Modified:** requirements_2.7.txt

**Change:** Downgrade `gevent` to `1.2.2`

I was having issues running the Flask and Celery containers. The issue was due to installing `gevent` version `1.4.0` which is not supported by Python 2 as it can be seen in the table at: https://pypi.org/project/gevent/#description

![image](https://user-images.githubusercontent.com/2656323/201452525-32dbb3e4-bea3-4dae-b620-df3fcae5fce0.png)


After using the supported `gevent` version the issue was solved.

I'm running the project on ubuntu server v22.04

Thank you.