### PR TITLE
Adds new parser category: cloud

### DIFF
--- a/kuiper/app/templates/admin/configuration.html
+++ b/kuiper/app/templates/admin/configuration.html
@@ -124,6 +124,7 @@
                           <option>autostart_locations</option>
                           <option>user_activities</option>
                           <option>memory</option>
+                          <option>cloud</option>
                         </select>
                       </div>
                       


### PR DESCRIPTION
The diverse and increasing cloudlogs require many parsers for which there is no suitable category yet. The new category "cloud" is a good place for them. 