### PR TITLE
Add Support for Decompression of tgz Archives

### DIFF
--- a/kuiper/app/templates/case/upload_machines.html
+++ b/kuiper/app/templates/case/upload_machines.html
@@ -185,7 +185,7 @@ jQuery(function($){
 			dataType                : 'json',
 			edit                    : false,
 			autoUpload              : false,
-			acceptFileTypes         : /(\.|\/)(zip)$/i,
+			acceptFileTypes         : /(\.|\/)(zip|tar\.gz|tgz)$/i,
 			maxFileSize             : 64000000000, // 64 GB
 			maxNumberOfFiles        : 100,
             sequentialUploads       : true,


### PR DESCRIPTION
File collections originating from Linux-based systems are sometimes compressed using `tar`. This PR adds support for the decompression of `*.tar.gz` archives in order to handle these archives correctly and to avoid the conversion to ZIP archives.