### PR TITLE
Add advanced table

### DIFF
--- a/kuiper/app/static/Kuiper.js
+++ b/kuiper/app/static/Kuiper.js
@@ -191,6 +191,55 @@ function build_windows_event_table(record , container) {
 }
 
 
+// build advanced table (contents of the 'Advanced' key will be shown as beautified json)
+function build_advanced_artifacts_table(records , container, searchable = true, spliter=true , group_by=true){
+    var open_badge = '<span class="badge bg-blue"> '
+    
+    var beautify = records['_source']['Data']['Advanced']
+    
+    var results = convert_json_to_list(records['_source'])
+    var rhaegal_hit = build_rhaegal_rules(records)
+
+    html = rhaegal_hit + "<table class=\"table table-condensed table_left_header\"><tbody>";
+    
+    var list_of_keys = []
+    for(var i = 0 ; i < results.length ; i++)
+        list_of_keys.push(results[i][0])
+    
+    // display the "tag_type" field
+    if(list_of_keys.indexOf("tag_type") != -1){
+        var i = list_of_keys.indexOf("tag_type")
+        var field = results[i][0].split('|').join('.');
+        var value = results[i][1];
+
+        var search_plus = (searchable) ? '<a id="' + field + ':' + value + '" class="clickable add_to_search_query float_right"><i class="fa fa-search-plus"></i></a>' : '';
+        var tag_color = (value in tags_color) ? tags_color[value] : tags_color["untag"];
+        var value_html = (field == "tag_type") ? '<small class="label bg-'+tag_color+'">'+value+'</small>': escapeHtml(value);
+        html += '<tr><td> ' + open_badge + " " + field + ' </span> ' + search_plus + '</td><td  style="min-width:250px">' + value_html + '</td></tr>';
+    }
+    for (var i = 0; i < results.length; i++) {
+        var field = results[i][0].split('|').join('.');
+        var value = results[i][1];
+
+        if(field.startsWith("Data.Advanced") || ["tag_type" , "tag_id"].indexOf(field) != -1 ) // skip these fields
+            continue 
+        var search_plus = (searchable) ? '<a id="' + field + ':' + value + '" class="clickable add_to_search_query" ><i class="fa fa-search-plus"></i></a>' : '';
+        var spliter_plus = (spliter) ? '<a field="' + field + '" class="clickable add_extra_column_table_records" style="margin-left:3px;"><i class="fa fa-columns"></i></a>' : '';
+        var group_by_plus = (group_by) ? '<a field="' + field + '" class="clickable add_group_by_table_records" style="margin-left:3px;"><i class="fa fa-object-group"></i></a>' : '';
+
+        html += '<tr><td  style="min-width:150px"><div class="float_right">' + group_by_plus + spliter_plus + " " + search_plus + '</div> <div style="margin-right:70px">' + open_badge + " " + field + ' </span></div></td><td  style="min-width:250px">' + escapeHtml(value) + '</td></tr>';
+    }
+    html = html + "</tbody></table>";
+    html = html + '<div class="box-header disabled color-palette"><b>Data.Advanced</b></div>';
+
+    html = html + '<pre><code id="event_json_viewer"></code></pre>';
+    
+
+    container.html(html);
+
+    $('#event_json_viewer').html(library.json.prettyPrint(beautify));
+}
+
 
 // build simple table (record contains key and values)
 // spliter, if true, the table shows spliter column to add it to the table

--- a/kuiper/app/templates/case/browse_artifacts.html
+++ b/kuiper/app/templates/case/browse_artifacts.html
@@ -2717,7 +2717,7 @@ $("#table_events").on('click' , 'tr td a.record_details_dialog_click' , function
     record_id   = $(this).attr('id');
     record      = ajax_records[record_id];
     results     = convert_json_to_list(record['_source']);
-    var container = $('#j')
+    var container = $('#dialog_content')
 
     build_simple_artifacts_table(records=record , container=container, searchable = true, spliter=true)
 });

--- a/kuiper/app/templates/case/browse_artifacts.html
+++ b/kuiper/app/templates/case/browse_artifacts.html
@@ -2675,9 +2675,11 @@ $("#table_events").on('click' , 'tr.event_record_click' , function(){
       // build the right side window depends on the data type
       var data_type = $(this).attr('data-type')
       if( data_type == "windows_events" || data_type == "Events" )
-        var html = build_windows_event_table(ajax_records[clicked_id] , $('#record_details'));     
+        var html = build_windows_event_table(ajax_records[clicked_id] , $('#record_details'));
+      else if( ajax_records[clicked_id]['_source']['Data'].hasOwnProperty('Advanced') )
+        var html = build_advanced_artifacts_table(ajax_records[clicked_id] , $('#record_details'));
       else
-        var html = build_simple_artifacts_table(ajax_records[clicked_id] , $('#record_details'), spliter=true);  
+        var html = build_simple_artifacts_table(ajax_records[clicked_id] , $('#record_details'), spliter=true);
       
 
       //$('#record_details').html(html);
@@ -2715,7 +2717,7 @@ $("#table_events").on('click' , 'tr td a.record_details_dialog_click' , function
     record_id   = $(this).attr('id');
     record      = ajax_records[record_id];
     results     = convert_json_to_list(record['_source']);
-    var container = $('#dialog_content')
+    var container = $('#j')
 
     build_simple_artifacts_table(records=record , container=container, searchable = true, spliter=true)
 });

--- a/kuiper/app/templates/case/timeline.html
+++ b/kuiper/app/templates/case/timeline.html
@@ -638,9 +638,10 @@ $('.timeline').on( 'click' , 'a.record_details_button' , function(){
     var data_type = record['_source']['data_type']
       if( data_type == "windows_events" )
         var html = build_windows_event_table(record , $('#record_details'));
-      else {
+      else if ( record['_source']['Data'].hasOwnProperty('Advanced') )
+        var html = build_advanced_artifacts_table(record, $('#record_details'), false);
+      else
         var html = build_simple_artifacts_table(record , $('#record_details') , false);
-      }
 
     $('#tag_details').find('.modal-body').html(html)
 


### PR DESCRIPTION
In cloud logs reside many nested objects. When flattening these, the key names kill the layout of the "simple artifact details table" due to the long names, eg. targetResources_0_modifiedProperties_1_displayName. Shortening is not meaningful possible and would probably remove the meaning of the value. We tried line-breaking within the blue badge, but this has an impact on the readability.

The "event artifact details table" is hardcoded on windows event artifacts but it uses a nice approach: The nested objects in those events are displayed as beautified Json at the bottom of the simple table. 

So we developed the "advanced artifact table". As soon as a key "Advanced" exists within the record, it's contents are beautified the same way as for windows-events. To make clear how to call these fields in advanced searches, it's headlined with "Data.Advanced".

![kuiper_advanced_arti_table](https://user-images.githubusercontent.com/122541728/236403360-0178c93f-635a-4e23-af21-c8f611fa96bf.png)
