### PR TITLE
Fix redis Dockerfile

### DIFF
--- a/Dockerfile.prod.redis
+++ b/Dockerfile.prod.redis
@@ -1,20 +1,16 @@
-FROM redis:latest
+FROM redis:7.0.11-bookworm
 
-RUN apt update
-RUN apt install -y python3 python3-pip cron
-RUN pip install --upgrade pip
-
-RUN pip install redis
-RUN pip install requests
-RUN pip install psutil
+RUN apt update && \
+    apt install --no-install-recommends -y python3 python3-pip python3-redis python3-requests python3-psutil cron
 
 COPY ./system_health/ /system_health/
 
 
 COPY ./system_health/crontabs/crontab.redis /etc/cron.d/crontab
-RUN chmod 0644 /etc/cron.d/crontab
-RUN crontab /etc/cron.d/crontab
-RUN touch /var/log/cron_redis.log
+
+RUN chmod 0644 /etc/cron.d/crontab && \
+    crontab /etc/cron.d/crontab && \
+    touch /var/log/cron_redis.log
 
 
 CMD cron && docker-entrypoint.sh redis-server


### PR DESCRIPTION
Redis recently switched to Debian 12 as base image. That in turn causes pip to fail because it's not allowed to install packages at the system level anymore.

Since all required packages are available as Debian packages, I switched to installing them via apt. I also pinned the image version to avoid future surprise breakage.