### PR TITLE
Improve api checks

### DIFF
--- a/kuiper/app/__init__.py
+++ b/kuiper/app/__init__.py
@@ -200,22 +200,21 @@ def before_request():
             request_str =  urllib.unquote(request.data).decode('utf8')
             request_json = json.loads(request_str)['data']
         except:
-            return redirect(url_for('error_api', error="error getting request json"))
+            return "Error getting request json", 400
 
         # API token can be in request json data or in forms data
         if 'api_token' in request_json:
             if request_json['api_token'] == app.config['FLASK_API_TOKEN']:
                 return
             else:
-                return redirect(url_for('error_api', error="invalid api token supplied"))
+                return "Invalid API token", 401
         elif 'api_token' in dict(request.form):
             if request.form["api_token"] == app.config['FLASK_API_TOKEN']:
                 return
             else:
-                return redirect(url_for('error_api', error="invalid api token supplied"))
+                return "Invalid API token", 401
         else:
-            return redirect(url_for('error_api', error="no api token supplied"))
-
+            return "No API token", 401
     
     if app.config['LDAP_ENABLED']  == False:
         return

--- a/kuiper/app/__init__.py
+++ b/kuiper/app/__init__.py
@@ -200,6 +200,7 @@ def before_request():
             request_str =  urllib.unquote(request.data).decode('utf8')
             request_json = json.loads(request_str)['data']
         except:
+            logger.logger(level=logger.ERROR , type="API", message="Bad Request" , reason="Error getting request json")
             return "Error getting request json", 400
 
         # API token can be in request json data or in forms data
@@ -207,13 +208,16 @@ def before_request():
             if request_json['api_token'] == app.config['FLASK_API_TOKEN']:
                 return
             else:
+                logger.logger(level=logger.ERROR , type="API", message="Unauthorized" , reason="Invalid API token")
                 return "Invalid API token", 401
         elif 'api_token' in dict(request.form):
             if request.form["api_token"] == app.config['FLASK_API_TOKEN']:
                 return
             else:
+                logger.logger(level=logger.ERROR , type="API", message="Unauthorized" , reason="Invalid API token")
                 return "Invalid API token", 401
         else:
+            logger.logger(level=logger.ERROR , type="API", message="Unauthorized" , reason="No API token")
             return "No API token", 401
     
     if app.config['LDAP_ENABLED']  == False:


### PR DESCRIPTION
This pr structures the API token checking function more logical and gives proper error messages. Especially it differentiates between API token errors and json parsing errors. The error messages are directly returned instead of forwarding to an error page (which broke deployments using http basic auth for everything but the API and thus made proper error checking at the client side harder).