### PR TITLE
Ask for confirmation before deleting cases and machines

### DIFF
--- a/kuiper/app/templates/admin/display_cases.html
+++ b/kuiper/app/templates/admin/display_cases.html
@@ -289,13 +289,18 @@ $('#edit_case_info_modal').on('hidden.bs.modal' , function(){
 })
 
 // stop moving to case page when delete button on case card clicked
-$('#cases_cards').on('click' , '.remove_case_info' , function(){ 
-    stop_moving_to_case_page = true;
-    var casename = $(this).attr('data')
-    $(this).closest('.col-md-3').remove()
+$('#cases_cards').on('click' , '.remove_case_info' , function(){
+    var casename = $(this).attr('data');
+    if (confirm("Are you sure you want to delete the case '" + casename + "'? This action is not reversible!")){
+      stop_moving_to_case_page = true;
+      $(this).closest('.col-md-3').remove()
 
-    var link = "../admin/delete_case/" + casename;
-    window.location.href=link;
+      var link = "../admin/delete_case/" + casename;
+      window.location.href=link;
+    }
+    else {
+      stop_moving_to_case_page = true;
+    }
 
 });
 

--- a/kuiper/app/templates/admin/display_cases.html
+++ b/kuiper/app/templates/admin/display_cases.html
@@ -72,6 +72,27 @@
   <!-- /.modal-dialog -->
 </div>
 
+<div class="modal fade" id="confirmModal" tabindex="-1" role="dialog" aria-labelledby="confirmModalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+      <div class="modal-content">
+          <div class="modal-header">
+              <h5 class="modal-title" id="confirmModalLabel">Confirm Deletion</h5>
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                  <span aria-hidden="true">&times;</span>
+              </button>
+          </div>
+          <div class="modal-body">
+              Are you sure you want to delete this case?
+          </div>
+          <input type="hidden" name="casename" id="casename" value="">
+          <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+              <button type="button" class="btn btn-primary" id="confirmDelete">Delete</button>
+          </div>
+      </div>
+  </div>
+</div>
+
 <!-- =============== END CREATE/UPDATE CASE dialog ================ -->
 
 
@@ -288,20 +309,23 @@ $('#edit_case_info_modal').on('hidden.bs.modal' , function(){
     stop_moving_to_case_page = false;
 })
 
-// stop moving to case page when delete button on case card clicked
-$('#cases_cards').on('click' , '.remove_case_info' , function(){
-    var casename = $(this).attr('data');
-    if (confirm("Are you sure you want to delete the case '" + casename + "'? This action is not reversible!")){
-      stop_moving_to_case_page = true;
-      $(this).closest('.col-md-3').remove()
+$('#cases_cards').on('click', '.remove_case_info', function () {
+    stop_moving_to_case_page = true;
+    $('#casename').val($(this).attr('data'));
+    $('#confirmModal .modal-body').text(
+      "Are you sure you wante to delete the case " + $('#casename').val() + "? \
+      This action is irreversible.");
+    $('#confirmModal').modal('show');
+});
 
-      var link = "../admin/delete_case/" + casename;
-      window.location.href=link;
-    }
-    else {
-      stop_moving_to_case_page = true;
-    }
+$('#confirmDelete').on('click', function () {
+    var casename = $('#casename').val();
+    var link = "../admin/delete_case/" + casename;
+    window.location.href=link;
+});
 
+$('#cancelDelete').on('click', function () {
+    $('#confirmModal').modal('hide');
 });
 
 // on click over case card, move to case page if not disabled

--- a/kuiper/app/templates/case/machines.html
+++ b/kuiper/app/templates/case/machines.html
@@ -348,6 +348,29 @@
       {% endif %}
   </div>
 
+<!-- =============== Confirmation popup ============== -->
+<div class="modal fade" id="confirmModal" tabindex="-1" role="dialog" aria-labelledby="confirmModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="confirmModalLabel">Confirm Deletion</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                Are you sure you want to delete the selected machines? This action is irreversible.
+            </div>
+            <input type="hidden" name="casename" id="casename" value="">
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="confirmDelete">Delete</button>
+            </div>
+        </div>
+    </div>
+  </div>
+  <!-- =============== END confirmation popup ================ -->
+
 
   <!-- =========== Machine Card START ============== -->
 
@@ -1097,13 +1120,17 @@ $('#parsers_box_container').on('click' , '.parsers_back_to_machines' , function(
 
 // when user click delete selected machines button
 $('#list_of_machines_box_container').on('click' , '.btn_delete_machine' , function(){
+    $('#confirmModal').modal('show');
+})
+
+$('#confirmDelete').on('click', function () {
     var selected_machineids = [];
     var caseid = null;
     $('.checkbox_process:checked').each(function(){
         selected_machineids.push($(this).data('machineid'))
         caseid = $(this).data('caseid')
     })
-    
+
     var url_page = '/case/'+Current_case+'/delete_machine/'+selected_machineids
     $.ajax({
             type: 'GET',
@@ -1118,7 +1145,9 @@ $('#list_of_machines_box_container').on('click' , '.btn_delete_machine' , functi
             });
 })
 
-
+$('#cancelDelete').on('click', function () {
+    $('#confirmModal').modal('hide');
+})
 
 
 // when user click processing button for selected machines


### PR DESCRIPTION
Add confirmation dialogs when the user tries to delete a case or machine(s), to prevent accidental deletion.